### PR TITLE
Add gdx-liftoff, a newer fork of gdx-setup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ Resources that can be used in libGDX code to boost the framework's capabilities.
 External tools to make development easier and faster.
 
 - [Gdx Texture Packer GUI](https://github.com/crashinvaders/gdx-texture-packer-gui) - A simple way to pack and manage texture atlases for libGDX game framework.
+- [gdx-liftoff](https://github.com/tommyettinger/gdx-liftoff) - A modern setup tool for libGDX that uses the current Gradle 5.x series.
 - [gdx-setup](https://github.com/czyzby/gdx-setup) - Alternative gdx-setup application - create your LibGDX projects with ease!
 - [Overlap2D](https://github.com/UnderwaterApps/overlap2d) - 2D level and UI editor with an engine agnostic philosophy for game development.
 - [Packr](https://github.com/libGDX/packr) - Packages your JAR, assets and a JVM for distribution on Windows, Linux and Mac OS X.


### PR DESCRIPTION
I hope this is all set up OK; I forked czyzby/gdx-setup a while ago for a different setup tool and just cleaned it up to release as a general libGDX setup app, gdx-liftoff. Targeting Gradle 5.4 instead of 4.6 or 4.0.2 means Java 8-12 all work with libGDX projects made with gdx-liftoff. There's also various other bugs fixed in Gradle 5.4, especially some that affect Android projects.