### PR TITLE
Add msdf-gdx and libgdx-kotlin-template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,12 +69,14 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 ### Setup and Deployment
 - [gdx-liftoff](https://github.com/tommyettinger/gdx-liftoff) - A modern setup tool for libGDX that uses the current Gradle 5.x series.
 - [Packr](https://github.com/libGDX/packr) - Packages your JAR, assets and a JVM for distribution on Windows, Linux and macOS.
+- [libgdx-kotlin-template](https://github.com/maltaisn/libgdx-kotlin-template) - Template project for libGDX using Kotlin and Kotlin gradle DSL.
 
 ### User Interface
 - [Freetype](https://github.com/libgdx/libgdx/wiki/Gdx-freetype) - Generate BitmapFonts of your desired size on the fly from lightweight .ttf font files.
 - [gdx-dialogs](https://github.com/TomGrill/gdx-dialogs) - Provides cross-platform support for native dialogs.
 - [gdx-skins](https://github.com/czyzby/gdx-skins) - Free Scene2D GUI skins.
 - [InGameConsole](https://github.com/StrongJoshua/libGDX-inGameConsole) - Allows a developer to add a console (similar to how it is featured in Source games) to their game.
+- [msdf-gdx](https://github.com/maltaisn/msdf-gdx) - Provides lightweight utilities to draw high-quality MSDF (multi-channel signed distance field) text on LibGDX.
 - [Ray3K Skins](https://ray3k.wordpress.com/artwork/) - Free Scene2D.UI skins with example code, custom drawables, and experimental features.
 - [Skin Composer](https://github.com/raeleus/skin-composer) - Create skins for libGDX scene2d.ui with a graphical interface.
 - [TenPatch](https://github.com/raeleus/TenPatch) - An alternative to libGDX's 9patch implementation that implements multiple stretch regions.


### PR DESCRIPTION
I added two of my projects:
- [msdf-gdx](https://github.com/maltaisn/msdf-gdx) - Provides lightweight utilities to draw high-quality MSDF (multi-channel signed distance field) text on LibGDX.
- [libgdx-kotlin-template](https://github.com/maltaisn/libgdx-kotlin-template) - Template project for libGDX using Kotlin and Kotlin gradle DSL.

I hope this is awesome enough and that you don't my the self promotion.