### PR TITLE
Added PieMenu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 - [gdx-skins](https://github.com/czyzby/gdx-skins) - Free Scene2D GUI skins.
 - [InGameConsole](https://github.com/StrongJoshua/libGDX-inGameConsole) - Allows a developer to add a console (similar to how it is featured in Source games) to their game.
 - [msdf-gdx](https://github.com/maltaisn/msdf-gdx) - Provides lightweight utilities to draw high-quality MSDF (multi-channel signed distance field) text on libGDX.
-- [PieMenu](https://github.com/payne911/PieMenu) - Circular menus (aka PieMenu) and widgets within libGDX scene2d.ui.
+- [PieMenu](https://github.com/payne911/PieMenu) - Radial menus for Scene2D that are highly flexible and easy to customize.
 - [Ray3K Skins](https://ray3k.wordpress.com/artwork/) - Free Scene2D.UI skins with example code, custom drawables, and experimental features.
 - [Skin Composer](https://github.com/raeleus/skin-composer) - Create skins for libGDX scene2d.ui with a graphical interface.
 - [TenPatch](https://github.com/raeleus/TenPatch) - An alternative to libGDX's 9patch implementation that implements multiple stretch regions.

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 - [gdx-dialogs](https://github.com/TomGrill/gdx-dialogs) - Provides cross-platform support for native dialogs.
 - [gdx-skins](https://github.com/czyzby/gdx-skins) - Free Scene2D GUI skins.
 - [InGameConsole](https://github.com/StrongJoshua/libGDX-inGameConsole) - Allows a developer to add a console (similar to how it is featured in Source games) to their game.
+- [PieMenu](https://github.com/payne911/PieMenu) - A library to obtain a circular WidgetGroup (aka RadialGroup or PieMenu) within libGDX.
 - [Ray3K Skins](https://ray3k.wordpress.com/artwork/) - Free Scene2D.UI skins with example code, custom drawables, and experimental features.
 - [Skin Composer](https://github.com/raeleus/skin-composer) - Create skins for libGDX scene2d.ui with a graphical interface.
 - [TenPatch](https://github.com/raeleus/TenPatch) - An alternative to libGDX's 9patch implementation that implements multiple stretch regions.


### PR DESCRIPTION
A library designed to allow users to incorporate radial widgets in their games.

The "scene2d standards" were respected whenever possible so as to allow the most fluid integration and exploration for users.
Moreover, a very extensive Wiki is provided, along with many examples showing off use-cases (with a GIF, an explanation, and the code).