### PR TITLE
Added jbump

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 ### Physics
 - [Box2D](https://github.com/libgdx/libgdx/wiki/Box2d) - One of the most popular physics libraries for 2D games.
 - [Bullet](https://github.com/libgdx/libgdx/wiki/Bullet-physics) - 3D Collision Detection and Rigid Body Dynamics Library.
+- [jbump](https://github.com/tommyettinger/jbump) - Easy to implement AABB collision detection useful for platformers and other simple 2D games.
 
 ### Services
 - [gdx-facebook](https://github.com/TomGrill/gdx-facebook) - Provides cross-platform support for Facebook Graph API.


### PR DESCRIPTION
jbump has been around for some time (since 2017), but hasn't been getting much attention. Actually, it's a simple port based on [bump.lua from LOVE2D](https://github.com/kikito/bump.lua/blob/master/README.md) which is even older (since 2012). This is a great alternative to Box2D for folks that just want simple collision detection or want to implement their own physics. [Video here](https://youtu.be/IeU06Vzz2hA).

I've made a game with it and several test projects and it worked well enough. Actually, Implicit Invocation's implementation had some really gnarly errors so TEttinger and I collaborated to fix the bugs, added new/missing functionality, and added a bunch of documentation. Implicit Invocation fell off the map and is longer responding to issues or PR's. That's why I linked TEttinger's fork instead of the original. It's pretty solid now and I don't plan on adding or changing much more unless I have a personal need. Please consider adding this library to your list. Thank you.