### PR TITLE
Add libgdx-screenmanager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 ### Visual Effects
 - [Box2DLights](https://github.com/libgdx/box2dlights) - 2D lighting framework that uses Box2D for raycasting and OpenGL ES 2.0 for rendering.
 - [gdx-vfx](https://github.com/crashinvaders/gdx-vfx) - Flexible post-processing shader visual effects based on libgdx-contribs-postprocessing.
+- [libgdx-screenmanager](https://github.com/crykn/libgdx-screenmanager) - A screen manager for libGDX supporting various transition effects
 - [Particle Park](https://github.com/raeleus/Particle-Park) - A showcase of downloadable particle effects with live previews.
 - [Shape Drawer](https://github.com/earlygrey/shapedrawer) - A performant alternative to ShapeRenderer that avoids Batch flushing.
 - [Spine](http://esotericsoftware.com/) - Skeleton-based animation tool that focuses specifically on 2D animation for games.


### PR DESCRIPTION
**A screen manager for libGDX supporting transition effects.** Handles the changing of screens and allows to apply effects during the transition from one screen to another (`screenManager.pushScreen("settings_screen", "blending_transition")`). Also supports transition shaders, so all the cool shaders on [gl-transitions](https://gl-transitions.com/gallery) can be used. 

Documentation is provided in the [wiki](https://github.com/crykn/libgdx-screenmanager/wiki) and the repo contains a simple [example](https://github.com/crykn/libgdx-screenmanager/tree/master/example) to get started.

Some of the effects that are possible:
![](https://raw.githubusercontent.com/crykn/libgdx-screenmanager/master/showcase/gl_transitions_2.gif)

