### PR TITLE
Update gradle version of gdx-liftoff

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 - [steamworks4j](https://github.com/code-disaster/steamworks4j) - A thin wrapper which allows Java applications to access the Steamworks C++ API.
 
 ### Setup and Deployment
-- [gdx-liftoff](https://github.com/tommyettinger/gdx-liftoff) - A modern setup tool for libGDX that uses the current Gradle 5.x series.
+- [gdx-liftoff](https://github.com/tommyettinger/gdx-liftoff) - A modern setup tool for libGDX that uses the current Gradle 7.x series.
 - [Packr](https://github.com/libGDX/packr) - Packages your JAR, assets and a JVM for distribution on Windows, Linux and macOS.
 
 ### User Interface


### PR DESCRIPTION
Hi!

I've updated the description of gdx-liftoff because it is outdated.