### PR TITLE
Add/update various tommyettinger libs.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,8 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 - [steamworks4j](https://github.com/code-disaster/steamworks4j) - A thin wrapper which allows Java applications to access the Steamworks C++ API.
 
 ### Setup and Deployment
-- [gdx-liftoff](https://github.com/tommyettinger/gdx-liftoff) - A modern setup tool for libGDX that uses the current Gradle 7.x series.
+- [gdx-liftoff](https://github.com/tommyettinger/gdx-liftoff) - A modern setup tool for libGDX that supports more backends and allows adding libraries with one click.
+- [libgdx-library-template](https://github.com/tommyettinger/libgdx-library-template) - A skeleton project for making new libraries, since they need different config.
 - [Packr](https://github.com/libGDX/packr) - Packages your JAR, assets and a JVM for distribution on Windows, Linux and macOS.
 
 ### User Interface
@@ -87,11 +88,13 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 - [Ray3K Skins](https://ray3k.wordpress.com/artwork/) - Free Scene2D.UI skins with example code, custom drawables, and experimental features.
 - [Skin Composer](https://github.com/raeleus/skin-composer) - Create skins for libGDX scene2d.ui with a graphical interface.
 - [TenPatch](https://github.com/raeleus/TenPatch) - An alternative to libGDX's 9patch implementation that implements multiple stretch regions.
+- [TextraTypist](https://github.com/tommyettinger/textratypist) - Like TypingLabel (below), but also supports styles, emoji, multiple fonts, clickable links, etc.
 - [TypingLabel](https://github.com/rafaskb/typing-label) - A libGDX Label that appears as if it was being typed in real time.
 - [VisUI](https://github.com/kotcrab/vis-ui) - Allows to create nice looking UI in libGDX using scene2d.ui. Note this is not a UI editor.
 
 ### Visual Effects
 - [Box2DLights](https://github.com/libgdx/box2dlights) - 2D lighting framework that uses Box2D for raycasting and OpenGL ES 2.0 for rendering.
+- [colorful-gdx](https://github.com/tommyettinger/colorful-gdx) - Expands how tinting can affect colors; also has many pre-written shaders.
 - [HackLights](https://github.com/aliasifk/HackLights) - Lightweight framebuffer based lighting engine for libGDX.
 - [gdx-vfx](https://github.com/crashinvaders/gdx-vfx) - Flexible post-processing shader visual effects based on libgdx-contribs-postprocessing.
 - [libgdx-screenmanager](https://github.com/crykn/libgdx-screenmanager) - A screen manager for libGDX supporting various transition effects
@@ -107,6 +110,7 @@ _Resources that can be used in libGDX code to boost the framework's capabilities
 - [gdx-pd](https://github.com/mgsx-dev/gdx-pd) - Pure Data extension for libGDX.
 
 ### Others
+- [anim8-gdx](https://github.com/tommyettinger/anim8-gdx) - Allows saving (animated) GIFs and PNGs from sequences of Pixmaps, with configurable dithering if needed.
 - [gdx-dbgagent](https://github.com/PokeMMO/gdx-dbgagent) - Java Agent for debugging common issues, like objects not being disposed and constants such as Color.WHITE being modified. 
 - [gdx-jnigen](https://github.com/libgdx/gdx-jnigen) - Small library that allows C/C++ code to be written inline with Java source code.
 - [gdxGifRecorder](https://github.com/Anuken/GDXGifRecorder) - A utility class that records a GIF and saves it automatically.


### PR DESCRIPTION
First off, this future-proofs the text for gdx-liftoff, since it may not be using Gradle 7.x for much longer, and should move to 8.x . After that, I added colorful-gdx, since it's been a spotlight project on the libGDX site and it would be nice to have it linked here also. To provide another option for GIFs in addition to Anuken's recorder that's already here, I added my anim8-gdx library. They're pretty different approaches. I added TextraTypist, since it is being used in other projects pretty often, and the text mentions TypingLabel below it. Lastly, I added the main reason for this PR, the library template, since there's nothing that really links to it, and people often seem to get lost configuring their new libraries for usage by libGDX without some guidance.

Thanks for considering this! Please let me know if you feel like some text should be changed.