### PR TITLE
Update SRFX links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ _Collection of free and high quality assets to get your game to the next level._
 - [OpenGameArt.org](https://opengameart.org/) - Repository offering a variety of open content assets.
 - [Game-Icons.net](http://game-icons.net/) - Repository containing heaps of cool game related graphics.
 - [bfxr.net](https://www.bfxr.net/) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: Flash + Download)
-- [chr15m.itch.io/jsfxr](https://chr15m.itch.io/jsfxr) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: java/web)
+- [chr15m.itch.io/jsfxr](https://chr15m.itch.io/jsfxr) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: javascript/web)
 - [freesound.org](https://freesound.org/) - Huge collaborative database of audio snippets, samples, recordings, bleeps.
 
 

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,8 @@ _Collection of free and high quality assets to get your game to the next level._
 - [Kenney Assets](https://kenney.nl/) - High quality assets for your game, from 2D and 3D art to sound effects.
 - [OpenGameArt.org](https://opengameart.org/) - Repository offering a variety of open content assets.
 - [Game-Icons.net](http://game-icons.net/) - Repository containing heaps of cool game related graphics.
-- [bfxr.net](https://www.bfxr.net/) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping.
+- [bfxr.net](https://www.bfxr.net/) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: Flash + Download)
+- [chr15m.itch.io/jsfxr](https://chr15m.itch.io/jsfxr) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: java/web)
 - [freesound.org](https://freesound.org/) - Huge collaborative database of audio snippets, samples, recordings, bleeps.
 
 

--- a/readme.md
+++ b/readme.md
@@ -152,8 +152,7 @@ _Collection of free and high quality assets to get your game to the next level._
 - [Kenney Assets](https://kenney.nl/) - High quality assets for your game, from 2D and 3D art to sound effects.
 - [OpenGameArt.org](https://opengameart.org/) - Repository offering a variety of open content assets.
 - [Game-Icons.net](http://game-icons.net/) - Repository containing heaps of cool game related graphics.
-- [bfxr.net](https://www.bfxr.net/) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: Flash + Download)
-- [chr15m.itch.io/jsfxr](https://chr15m.itch.io/jsfxr) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping. (SFXR: javascript/web)
+- [Jsfxr](https://chr15m.itch.io/jsfxr) - Quickly create unique sound effects by pressing a few buttons, excellent for prototyping.
 - [freesound.org](https://freesound.org/) - Huge collaborative database of audio snippets, samples, recordings, bleeps.
 
 


### PR DESCRIPTION
The original Bfxr depends on Flash: "Adobe Flash Player version 11.1.0 or greater is installed."

Flash is obsolete, but the download is still valid so I didn't remove. added notes.

Added alternative modern javascript web version of the same SRFX tool.
